### PR TITLE
Change disk specific auxiliary data referencing

### DIFF
--- a/libvdsk/qcow.c
+++ b/libvdsk/qcow.c
@@ -38,6 +38,7 @@ __FBSDID("$FreeBSD: user/marcel/libvdsk/libvdsk/qcow.c 286996 2015-08-21 15:20:0
 #include <string.h>
 
 #include "vdsk_int.h"
+#include "qcow.h"
 
 /* Flag bits in cluster offsets */
 #define	QCOW_CLSTR_COMPRESSED	(1ULL << 62)

--- a/libvdsk/qcow.c
+++ b/libvdsk/qcow.c
@@ -62,6 +62,12 @@ copy_cluster(struct vdsk *vdsk, struct vdsk *vdsk_base, off_t dst, off_t src);
 static void
 inc_refs(struct vdsk *vdsk, off_t off, int newcluster);
 
+static struct qcdsk*
+qcow_deref(struct vdsk *vdsk)
+{
+	return (struct qcdsk*) vdsk - 1;
+}
+
 static int
 qcow_probe(struct vdsk *vdsk)
 {
@@ -103,7 +109,7 @@ qcow_open(struct vdsk *vdsk)
 {
 
 	struct qcheader *header;
-	struct qcdsk *qc = &vdsk->aux_data.qcow;
+	struct qcdsk *qc = qcow_deref(vdsk);
 	struct stat st;
 	size_t i;
 	char basepath[MAXPATHLEN];
@@ -181,7 +187,7 @@ qcow_open(struct vdsk *vdsk)
 			goto err_l1_out;
 		}
 
-		if (qc->base->aux_data.qcow.clustersz != qc->clustersz) {
+		if (qcow_deref(qc->base)->clustersz != qc->clustersz) {
 			printf("all disks must share clustersize\n");
 			goto err_base_out;
 		}
@@ -236,7 +242,7 @@ qcow_close(struct vdsk *vdsk)
 
 	struct qcdsk *disk;
 
-	disk = &vdsk->aux_data.qcow;
+	disk = qcow_deref(vdsk);
 
 	if (disk->base)
 		qcow_close(disk->base);
@@ -261,7 +267,7 @@ qcow_readv(struct vdsk *vdsk, const struct iovec *iov,
 	iov_rem = 0;
 	read = 0;
 	ioc = 0;
-	disk = &vdsk->aux_data.qcow;
+	disk = qcow_deref(vdsk);
 	rem = 0;
 
 	pthread_rwlock_rdlock(&disk->lock);
@@ -289,7 +295,7 @@ qcow_readv(struct vdsk *vdsk, const struct iovec *iov,
 		return -1;
 	}
 	while (rem > 0) {
-		for (d = vdsk; d; d = d->aux_data.qcow.base) {
+		for (d = vdsk; d; d = qcow_deref(d)->base) {
 			if ((phys_off = xlate(d, offset, NULL)) > 0) {
 				break;
 			}
@@ -378,7 +384,7 @@ xlate(struct vdsk *vdsk, off_t off, int *inplace)
 	struct qcdsk *disk;
 	int read;
 
-	disk = &vdsk->aux_data.qcow;
+	disk = qcow_deref(vdsk);
 
 	if (inplace)
 		*inplace = 0;
@@ -439,7 +445,7 @@ qcow_writev(struct vdsk *vdsk, const struct iovec *iov,
 	iov_rem = 0;
 	wrote = 0;
 	ioc = 0;
-	disk = &vdsk->aux_data.qcow;
+	disk = qcow_deref(vdsk);
 	rem = 0;
 	inplace = 1;
 	pthread_rwlock_wrlock(&disk->lock);
@@ -482,7 +488,7 @@ qcow_writev(struct vdsk *vdsk, const struct iovec *iov,
 		}
 
 		if (phys_off == 0) {
-			for (d = disk->base; d; d = d->aux_data.qcow.base)
+			for (d = disk->base; d; d = qcow_deref(d)->base)
 				if ((phys_off = xlate(d, offset, NULL)) > 0)
 					break;
 		}
@@ -547,8 +553,8 @@ mkcluster(struct vdsk *vdsk, struct vdsk *vdsk_base, off_t off, off_t src_phys)
 	int fd;
 	struct qcdsk *disk, *base;
 
-	disk = &vdsk->aux_data.qcow;
-	base = &vdsk_base->aux_data.qcow;
+	disk = qcow_deref(vdsk);
+	base = qcow_deref(vdsk_base);
 
 	cluster = -1;
 	fd = vdsk->fd;
@@ -647,8 +653,8 @@ copy_cluster(struct vdsk *vdsk, struct vdsk *vdsk_base, off_t dst, off_t src)
 
 	ret = 0;
 
-	disk = &vdsk->aux_data.qcow;
-	base = &vdsk_base->aux_data.qcow;
+	disk = qcow_deref(vdsk);
+	base = qcow_deref(vdsk_base);
 
 	scratch = alloca(disk->clustersz);
 	if (!scratch) {
@@ -683,7 +689,7 @@ inc_refs(struct vdsk *vdsk, off_t off, int newcluster)
 	uint64_t buf;
 	struct qcdsk *disk;
 
-	disk = &vdsk->aux_data.qcow;
+	disk = qcow_deref(vdsk);
 
 	off &= ~QCOW2_INPLACE;
 	nper = disk->clustersz / 2;
@@ -749,7 +755,7 @@ static int
 qcow_flush(struct vdsk *vdsk)
 {
 	int error;
-	struct qcdsk *disk = &vdsk->aux_data.qcow;
+	struct qcdsk *disk = qcow_deref(vdsk);
 
 	error = 0;
 	if (vdsk_is_dev(vdsk)) {
@@ -771,6 +777,7 @@ static struct vdsk_format qcow_format = {
 	.name = "qcow",
 	.description = "QEMU Copy-On-Write, version 1",
 	.flags = VDSKFMT_CAN_WRITE | VDSKFMT_HAS_HEADER,
+	.struct_size = sizeof(struct qcdsk),
 	.probe = qcow_probe,
 	.open = qcow_open,
 	.close = qcow_close,

--- a/libvdsk/qcow.h
+++ b/libvdsk/qcow.h
@@ -1,0 +1,89 @@
+/*-
+ * Copyright (c) 2019 Sergiu Weisz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#ifndef __QCOW_H__
+#define	__QCOW_H__
+
+/* QCOW HEADER */
+struct qcheader {
+	uint32_t	magic;
+	uint32_t	version;
+	uint64_t	backingoff;
+	uint32_t	backingsz;
+	uint32_t	clustershift;
+	uint64_t	disksz;
+	/* v2 */
+	uint32_t	cryptmethod;
+	uint32_t	l1sz;
+	uint64_t	l1off;
+	uint64_t	refoff;
+	uint32_t	refsz;
+	uint32_t	snapcount;
+	uint64_t	snapsz;
+	/* v3 */
+	uint64_t	incompatfeatures;
+	uint64_t	compatfeatures;
+	uint64_t	autoclearfeatures;
+	uint32_t	reforder; /* Bits = 1 << reforder */
+	uint32_t	headersz;
+} __packed;
+
+struct qcdsk {
+	/* QCOW */
+	struct qcheader header;
+	struct vdsk *vdsk;
+	struct vdsk *base;
+
+	uint64_t	*l1;
+	off_t		end;
+	off_t		clustersz;
+	off_t		disksz; /* In bytes */
+	uint32_t	cryptmethod;
+
+	uint32_t	l1sz;
+	off_t		l1off;
+
+	uint32_t	l2sz;
+	off_t		l2off;
+
+	off_t		refoff;
+	off_t		refsz;
+
+	uint32_t	nsnap;
+	off_t		snapoff;
+
+	/* v3 */
+	uint64_t	incompatfeatures;
+	uint64_t	autoclearfeatures;
+	uint32_t	refssz;
+	uint32_t	headersz;
+
+#ifdef SMP
+	pthread_rwlock_t lock;
+#endif
+};
+#endif

--- a/libvdsk/raw.c
+++ b/libvdsk/raw.c
@@ -263,6 +263,7 @@ static struct vdsk_format raw_format = {
 	.name = "raw",
 	.description = "Raw Disk File or Device",
 	.flags = VDSKFMT_CAN_WRITE | VDSKFMT_DEVICE_OK | VDSKFMT_NO_METADATA,
+	.struct_size = 0,
 	.probe = raw_probe,
 	.open = raw_open,
 	.close = raw_close,

--- a/libvdsk/vdsk_int.h
+++ b/libvdsk/vdsk_int.h
@@ -61,62 +61,6 @@ struct vdsk_format {
 SET_DECLARE(libvdsk_formats, struct vdsk_format);
 #define	FORMAT_DEFINE(nm)	DATA_SET(libvdsk_formats, nm)
 
-/* QCOW HEADER */
-struct qcheader {
-	uint32_t	magic;
-	uint32_t	version;
-	uint64_t	backingoff;
-	uint32_t	backingsz;
-	uint32_t	clustershift;
-	uint64_t	disksz;
-	/* v2 */
-	uint32_t	cryptmethod;
-	uint32_t	l1sz;
-	uint64_t	l1off;
-	uint64_t	refoff;
-	uint32_t	refsz;
-	uint32_t	snapcount;
-	uint64_t	snapsz;
-	/* v3 */
-	uint64_t	incompatfeatures;
-	uint64_t	compatfeatures;
-	uint64_t	autoclearfeatures;
-	uint32_t	reforder; /* Bits = 1 << reforder */
-	uint32_t	headersz;
-} __packed;
-
-struct qcdsk {
-	/* QCOW */
-	struct qcheader header;
-	struct vdsk *vdsk;
-	struct vdsk *base;
-
-	uint64_t	*l1;
-	off_t		end;
-	off_t		clustersz;
-	off_t		disksz; /* In bytes */
-	uint32_t	cryptmethod;
-
-	uint32_t	l1sz;
-	off_t		l1off;
-
-	uint32_t	l2sz;
-	off_t		l2off;
-
-	off_t		refoff;
-	off_t		refsz;
-
-	uint32_t	nsnap;
-	off_t		snapoff;
-
-	/* v3 */
-	uint64_t	incompatfeatures;
-	uint64_t	autoclearfeatures;
-	uint32_t	refssz;
-	uint32_t	headersz;
-	pthread_rwlock_t lock;
-};
-
 /*
  * The internal representation of a "disk".
  */

--- a/libvdsk/vdsk_int.h
+++ b/libvdsk/vdsk_int.h
@@ -49,6 +49,7 @@ struct vdsk_format {
 #define	VDSKFMT_NO_METADATA	0
 #define	VDSKFMT_HAS_FOOTER	4
 #define	VDSKFMT_HAS_HEADER	8
+	size_t	struct_size;
 	int	(*probe)(struct vdsk *);
 	int	(*open)(struct vdsk *);
 	int	(*close)(struct vdsk *);
@@ -76,14 +77,10 @@ struct vdsk {
 	int	stripe_size;
 	int	stripe_offset;
 	int	options;
-	void *aux;
-	union {
-		struct qcdsk qcow;
-	} aux_data;
 #define	VDSK_DOES_TRIM		1
 #define	VDSK_IS_GEOM		2
 #define	VDSK_TRACE		4
-} __attribute__((aligned(16)));
+};
 
 
 static inline int


### PR DESCRIPTION
Up until now we used a void pointer to the disk specific data in the
vdsk structure.

Now we allocate a bigger area and get to the disk specific data by
subtracting the size of the structure from the pointer to the vdsk
structure.

In order to do this, we need to store the size of the structure in the
vdsk_format structure.

This decreases the amount of indirections we have to do for each
operation.

For this change I also had to move the qcow specific disk data to its own header.