### PR TITLE
libvdsk: Add explicit error messages for unsupported formats

### DIFF
--- a/libvdsk/vdsk_int.h
+++ b/libvdsk/vdsk_int.h
@@ -123,4 +123,6 @@ vdsk_trace_leave(const char *func, int count, const char *arg1,
 #define DPRINTF(format, arg...)
 #endif
 
+#define ERRPRINTF(format, arg...) dprintf(STDERR_FILENO, format, ##arg)
+
 #endif /* __VDSK_INT_H__ */


### PR DESCRIPTION
I have added a new macro for printing errors to STDERR and added checks for ENOSYS.